### PR TITLE
Add Apple Music API hostnames to darwin exclusions

### DIFF
--- a/sysproxy/exclusions/darwin.txt
+++ b/sysproxy/exclusions/darwin.txt
@@ -180,5 +180,9 @@ api.config.opr.gg
 autoupdate.opera.com
 download.opera.com
 operacdn.com
+
+# Apple Music app
+amp-api.music.apple.com
+amp-api-edge.music.apple.com
 # </misc>
 


### PR DESCRIPTION
### What does this PR do?

Adds two `music.apple.com` subdomains to the macOS proxy exclusions list, which fixes the following "Something went wrong. Please try again later." error in Apple Music (likely cert pinning):
<img width="1092" height="712" alt="image" src="https://github.com/user-attachments/assets/cde09212-15e8-4ae9-8fac-8a06b4a3bc4a" />


### How did you verify your code works?
Manually added the domains to "Ignored Hosts" in Settings in Zen.

### What are the relevant issues?
