### PR TITLE
Fix blocked response creation by explicit assignment of Content-Length

### DIFF
--- a/networkrules/response.go
+++ b/networkrules/response.go
@@ -7,7 +7,6 @@ import (
 	"html/template"
 	"io"
 	"net/http"
-	"strconv"
 
 	"github.com/ZenPrivacy/zen-core/networkrules/rule"
 )
@@ -58,17 +57,17 @@ func (nr *NetworkRules) CreateBlockPageResponse(req *http.Request, appliedRules 
 	h := make(http.Header)
 	h.Set("Content-Type", "text/html; charset=utf-8")
 	h.Set("Cache-Control", "no-store")
-	h.Set("Content-Length", strconv.Itoa(buf.Len()))
 
 	return &http.Response{
-		StatusCode: http.StatusOK,
-		Status:     http.StatusText(http.StatusOK),
-		Proto:      req.Proto,
-		ProtoMajor: req.ProtoMajor,
-		ProtoMinor: req.ProtoMinor,
-		Header:     h,
-		Body:       io.NopCloser(&buf),
-		Request:    req,
+		StatusCode:    http.StatusOK,
+		Status:        http.StatusText(http.StatusOK),
+		Proto:         req.Proto,
+		ProtoMajor:    req.ProtoMajor,
+		ProtoMinor:    req.ProtoMinor,
+		Header:        h,
+		ContentLength: int64(buf.Len()),
+		Body:          io.NopCloser(&buf),
+		Request:       req,
 	}, nil
 }
 


### PR DESCRIPTION
### What does this PR do?

Blocked page responses generated by `NetworkRules.CreateBlockPageResponse` are currently sent without a `Content-Length` header:
<img width="266" height="95" alt="image" src="https://github.com/user-attachments/assets/ad79638d-c8e8-4695-bfd6-e206aca1cabd" />

This causes infinite loading in browsers, as shown below (some do end up showing the page eventually, but the UX is subpar):

<img width="255" height="23" alt="image" src="https://github.com/user-attachments/assets/19e0a634-2f7a-44ea-a034-8384b658f572" />
<br />
<img width="238" height="49" alt="image" src="https://github.com/user-attachments/assets/4df19a8f-d9a8-46fe-8856-397b77413f51" />

It isn't obvious from the documentation, but examining the `net/http` source code shows that a manually set `Content-Length` header on a `Response` is not actually sent to the client – see `Response.Write`: [[1]](https://cs.opensource.google/go/go/+/refs/tags/go1.25.3:src/net/http/response.go;l=307), [[2]](https://cs.opensource.google/go/go/+/refs/tags/go1.25.3:src/net/http/response.go;l=25).

The header is written by [`transferWriter.writeHeader` ](https://cs.opensource.google/go/go/+/refs/tags/go1.25.3:src/net/http/response.go;l=301), which uses the `ContentLength` struct field to determine the value: [[3]](https://cs.opensource.google/go/go/+/refs/tags/go1.25.3:src/net/http/transfer.go;l=295).

This PR fixes this issue by setting `Content-Length` via the struct field rather than the header map.

### How did you verify your code works?
Manual testing with Zen.

### What are the relevant issues?

<!--
**Please link any relevant issues**, for example:

Closes #123
-->
