### PR TITLE
Fix hosts rules parsing by fixing the store pattern

### DIFF
--- a/networkrules/networkrules.go
+++ b/networkrules/networkrules.go
@@ -53,10 +53,11 @@ func (nr *NetworkRules) ParseRule(rawRule string, filterName *string) (isExcepti
 				continue
 			}
 
-			pattern := fmt.Sprintf("||%s^$document", host)
+			pattern := fmt.Sprintf("||%s^", host)
 			nr.primaryStore.Insert(pattern, &rule.Rule{
-				RawRule:    pattern,
+				RawRule:    rawRule,
 				FilterName: filterName,
+				Document:   true,
 			})
 		}
 


### PR DESCRIPTION
### What does this PR do?
Fixes hosts rules parsing in `NetworkRules.ParseRule` by properly constructing the matching pattern.

### How did you verify your code works?
Manual testing in Zen.

### What are the relevant issues?
resolves https://github.com/ZenPrivacy/zen-desktop/issues/498
