### PR TITLE
Fix incorrect document navigation detection

### DIFF
--- a/filter/filter.go
+++ b/filter/filter.go
@@ -377,7 +377,7 @@ func isDocumentNavigation(req *http.Request, res *http.Response) bool {
 	// Note: Although not explicitly stated in the spec, Fetch Metadata Request Headers are only included in requests sent to HTTPS endpoints.
 	if req.URL.Scheme == "https" {
 		secFetchDest := req.Header.Get("Sec-Fetch-Dest")
-		if secFetchDest != "document" && secFetchDest == "iframe" {
+		if secFetchDest != "document" && secFetchDest != "iframe" {
 			return false
 		}
 	}


### PR DESCRIPTION
### What does this PR do?
Mostly self-explanatory.

Browsers send `Sec-Fetch-Dest: document` on requests for attachments.
The result of `isDocumentNavigation` determines whether injectors run on the HTTP response body, which in turn caused encoding issues in downloaded assets (`Content-Type: application/octet-stream`/`Content-Disposition: attachment`) with Zen enabled.

This PR fixes that by making the function also check the `Content-Type` to properly determine HTML document responses.

### How did you verify your code works?
Manual testing with Zen.

### What are the relevant issues?
https://github.com/ZenPrivacy/zen-desktop/issues/534
