### PR TITLE
Refactor darwin system proxy management by setting proxy for all interfaces

### DIFF
--- a/sysproxy/system_darwin.go
+++ b/sysproxy/system_darwin.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"os/exec"
 	"strings"
+
+	"github.com/hashicorp/go-multierror"
 )
 
 var (
@@ -50,15 +52,16 @@ func unsetSystemProxy() error {
 		return nil
 	}
 
+	var result error
 	for _, svc := range networkServices {
 		cmd := exec.Command("networksetup", "-setautoproxystate", svc, "off")
 		if out, err := cmd.CombinedOutput(); err != nil {
-			return fmt.Errorf("set autoproxystate to off for network service %q: %v (%q)", svc, err, out)
+			result = multierror.Append(result, fmt.Errorf("set autoproxystate to off for network service %q: %v (%q)", svc, err, out))
 		}
 	}
 
 	networkServices = nil
-	return nil
+	return result
 }
 
 // discoverNetworkServices returns a list of all network service names.


### PR DESCRIPTION
### What does this PR do?
This specifically fixes:
1. Switching between network services when the proxy has already been set.
2. Enabling proxy with certain VPNs that create a separate network interface with no mapping to a network interface, like Proton.

### How did you verify your code works?
Manual testing with Zen.

### What are the relevant issues?
ZenPrivacy/zen-desktop#363 ZenPrivacy/zen-desktop#84 ZenPrivacy/zen-desktop#59
