### PR TITLE
Optimize ruletree matching by only starting traversal from special characters

### DIFF
--- a/ruletree/ruletree.go
+++ b/ruletree/ruletree.go
@@ -194,14 +194,15 @@ func longestPrefix(a, b []token) int {
 	return maxLen
 }
 
+// traversalMarkers indicate traversal starting points in a URL.
 var traversalMarkers [256]bool
 
 func init() {
 	for _, ch := range "-._~:/?#[]@!$&'()*+,;%=" {
-		separators[ch] = true
+		traversalMarkers[ch] = true
 	}
 }
 
 func isTraversalMarker(char byte) bool {
-	return separators[char]
+	return traversalMarkers[char]
 }


### PR DESCRIPTION
### What does this PR do?
Improves `ruletree.Get` performance by only starting `root` traversal from a set of special characters (`traversalMarkers`).

See the benchmarks below. The improvements in realistic environments (more filter lists) are more notable (closer to 4-5x jump in performance).

#### Benchmark 1 (x64, AMD Ryzen 3600)
##### Baseline (`master`)
```bash
$ go test -bench=. -run=^$ ./ruletree
goos: windows
goarch: amd64
pkg: github.com/ZenPrivacy/zen-core/ruletree
cpu: AMD Ryzen 5 3600 6-Core Processor
BenchmarkLoadTree-12                  18          57587300 ns/op          42.21 MB/s    31694669 B/op     937038 allocs/op
BenchmarkMatch-12                  79832             14977 ns/op          11.55 MB/s          64 B/op          1 allocs/op
BenchmarkMatchParallel-12         616057              1995 ns/op          86.74 MB/s          64 B/op          1 allocs/op
```

##### Updated
```bash
$ go test -bench=. -run=^$ ./ruletree
goos: windows
goarch: amd64
pkg: github.com/ZenPrivacy/zen-core/ruletree
cpu: AMD Ryzen 5 3600 6-Core Processor
BenchmarkLoadTree-12                  18          58587211 ns/op          41.49 MB/s    31694936 B/op     937038 allocs/op
BenchmarkMatch-12                 127860              9470 ns/op          18.27 MB/s          64 B/op          1 allocs/op
BenchmarkMatchParallel-12         936453              1279 ns/op         135.28 MB/s          64 B/op          1 allocs/op
```

#### Benchmark 2 (arm64, Apple M2 Max)
##### Baseline (`master`)
```bash
$ go test -bench=. -run=^$ ./ruletree
goos: darwin
goarch: arm64
pkg: github.com/ZenPrivacy/zen-core/ruletree
cpu: Apple M2 Max
BenchmarkLoadTree-12                  32          35720342 ns/op          65.19 MB/s    31694043 B/op     937037 allocs/op
BenchmarkMatch-12                 103732             11318 ns/op          15.29 MB/s          65 B/op          1 allocs/op
BenchmarkMatchParallel-12         941289              1267 ns/op         136.56 MB/s          64 B/op          1 allocs/op
```

##### Updated
```bash
$ go test -bench=. -run=^$ ./ruletree
goos: darwin
goarch: arm64
pkg: github.com/ZenPrivacy/zen-core/ruletree
cpu: Apple M2 Max
BenchmarkLoadTree-12                  33          35016390 ns/op          66.50 MB/s    31694009 B/op        937037 allocs/op
BenchmarkMatch-12                 178320              6593 ns/op          26.24 MB/s          64 B/op             1 allocs/op
BenchmarkMatchParallel-12    1626138           745.0 ns/op       232.21 MB/s          64 B/op          1 allocs/op
```

### How did you verify your code works?
Existing unit tests.

### What are the relevant issues?
Addresses https://github.com/ZenPrivacy/zen-desktop/issues/520