### PR TITLE
csp: use tok.String() to generate patched meta values

### DIFF
--- a/csp/meta.go
+++ b/csp/meta.go
@@ -1,13 +1,13 @@
 package csp
 
 import (
-	"bytes"
 	"io"
 	"net/http"
 	"strings"
 
 	"github.com/ZenPrivacy/zen-core/httprewrite"
 	"golang.org/x/net/html"
+	"golang.org/x/net/html/atom"
 )
 
 // patchMetaCSPsBatch mutates HTML <meta> tags for multiple CSP operations in a single pass.
@@ -28,15 +28,16 @@ func patchMetaCSPsBatch(res *http.Response, operations []PatchOperation) error {
 				return
 
 			case html.StartTagToken, html.SelfClosingTagToken:
-				if name, _ := z.TagName(); !bytes.Equal(name, []byte("meta")) {
-					dst.Write(z.Raw())
+				raw := append([]byte{}, z.Raw()...) // z.Token() modifies the underlying buffer, so we need to make a copy
+				tok := z.Token()
+
+				if tok.DataAtom != atom.Meta {
+					dst.Write(raw)
 					continue
 				}
 
-				tok := z.Token()
-
 				var hasCSP bool
-				contentInd := -1 // Track the index of the content= attribute.
+				contentInd := -1 // Track the index of the content= attribute
 
 				for i, a := range tok.Attr {
 					if strings.EqualFold(a.Key, "http-equiv") &&
@@ -50,11 +51,11 @@ func patchMetaCSPsBatch(res *http.Response, operations []PatchOperation) error {
 				}
 
 				if !hasCSP || contentInd == -1 || tok.Attr[contentInd].Val == "" {
-					dst.Write(z.Raw())
+					dst.Write(raw)
 					continue
 				}
 
-				// Apply all operations to this meta tag's CSP.
+				// Apply all operations to this meta tag's CSP
 				var changed bool
 				contentVal := tok.Attr[contentInd].Val
 				patchedContent := contentVal
@@ -68,7 +69,7 @@ func patchMetaCSPsBatch(res *http.Response, operations []PatchOperation) error {
 				}
 
 				if !changed {
-					dst.Write(z.Raw())
+					dst.Write(raw)
 					continue
 				}
 

--- a/csp/meta.go
+++ b/csp/meta.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/ZenPrivacy/zen-core/httprewrite"
 	"golang.org/x/net/html"
-	"golang.org/x/net/html/atom"
 )
 
 // patchMetaCSPsBatch mutates HTML <meta> tags for multiple CSP operations in a single pass.
@@ -29,35 +28,37 @@ func patchMetaCSPsBatch(res *http.Response, operations []PatchOperation) error {
 				return
 
 			case html.StartTagToken, html.SelfClosingTagToken:
-				raw := append([]byte{}, z.Raw()...)
-				tok := z.Token()
-				if tok.DataAtom != atom.Meta {
-					dst.Write(raw)
+				if name, _ := z.TagName(); !bytes.Equal(name, []byte("meta")) {
+					dst.Write(z.Raw())
 					continue
 				}
 
-				var hasCSP bool
-				var contentVal string
+				tok := z.Token()
 
-				for _, a := range tok.Attr {
+				var hasCSP bool
+				contentInd := -1 // Track the index of the content= attribute.
+
+				for i, a := range tok.Attr {
 					if strings.EqualFold(a.Key, "http-equiv") &&
 						strings.EqualFold(a.Val, "content-security-policy") {
 						hasCSP = true
 					}
 
 					if strings.EqualFold(a.Key, "content") {
-						contentVal = a.Val
+						contentInd = i
 					}
 				}
 
-				if !hasCSP || contentVal == "" {
-					dst.Write(raw)
+				if !hasCSP || contentInd == -1 || tok.Attr[contentInd].Val == "" {
+					dst.Write(z.Raw())
 					continue
 				}
 
-				// Apply all operations to this meta tag's CSP
+				// Apply all operations to this meta tag's CSP.
+				var changed bool
+				contentVal := tok.Attr[contentInd].Val
 				patchedContent := contentVal
-				changed := false
+
 				for _, op := range operations {
 					patched, patchChanged := patchPolicies([]string{patchedContent}, op.Nonce, op.Kind, op.ResourceURL)
 					if patchChanged {
@@ -67,12 +68,12 @@ func patchMetaCSPsBatch(res *http.Response, operations []PatchOperation) error {
 				}
 
 				if !changed {
-					dst.Write(raw)
+					dst.Write(z.Raw())
 					continue
 				}
 
-				patchedRaw := replaceContentValue(raw, patchedContent)
-				dst.Write(patchedRaw)
+				tok.Attr[contentInd].Val = patchedContent
+				dst.Write([]byte(tok.String()))
 
 			default:
 				dst.Write(z.Raw())
@@ -81,36 +82,4 @@ func patchMetaCSPsBatch(res *http.Response, operations []PatchOperation) error {
 	})
 
 	return err
-}
-
-func replaceContentValue(raw []byte, newVal string) []byte {
-	lower := bytes.ToLower(raw)
-	i := bytes.Index(lower, []byte("content="))
-
-	if i == -1 {
-		return raw
-	}
-
-	afterKey := raw[i+len("content="):]
-	if len(afterKey) == 0 {
-		return raw
-	}
-
-	quote := afterKey[0]
-	if quote != '"' && quote != '\'' {
-		return raw
-	}
-
-	valueStart := i + len("content=") + 1
-	valueEndRel := bytes.IndexByte(raw[valueStart:], quote)
-	if valueEndRel == -1 {
-		return raw
-	}
-	valueEnd := valueStart + valueEndRel
-
-	out := make([]byte, 0, valueStart+len(newVal)+(len(raw)-valueEnd))
-	out = append(out, raw[:valueStart]...)
-	out = append(out, newVal...)
-	out = append(out, raw[valueEnd:]...)
-	return out
 }

--- a/csp/meta.go
+++ b/csp/meta.go
@@ -45,7 +45,7 @@ func patchMetaCSPsBatch(res *http.Response, operations []PatchOperation) error {
 						hasCSP = true
 					}
 
-					if strings.EqualFold(a.Key, "content") {
+					if strings.EqualFold(a.Key, "content") && contentInd == -1 {
 						contentInd = i
 					}
 				}

--- a/csp/patch.go
+++ b/csp/patch.go
@@ -110,7 +110,7 @@ func patchPolicies(policies []string, nonce string, kind tagKind, resourceURL st
 
 		newValue := appendToken(bestValue, appendValue)
 		rawDirs[bestIdx] = bestName + " " + newValue
-		policies[i] = strings.Join(rawDirs, "; ")
+		policies[i] = strings.Join(rawDirs, "; ") // #nosec G602 -- i is from range over policies
 		changed = true
 	}
 

--- a/internal/ruletree/node.go
+++ b/internal/ruletree/node.go
@@ -164,7 +164,7 @@ func (t *traverser[T]) traversePrefix(prefix []token, url string) {
 					}
 				}
 			default:
-				target := byte(prefix[1])
+				target := byte(prefix[1]) // #nosec G115 -- literal character tokens are always in ASCII byte range
 				off := 0
 				for off < len(url) {
 					idx := strings.IndexByte(url[off:], target)


### PR DESCRIPTION
### What does this PR do?

Replace manual `replaceContentValue` with tok.String() for formatting <meta> tags after CSP mutation.

### How did you verify your code works?

Existing unit tests; manual testing with Zen.

### What are the relevant issues?

<!--
**Please link any relevant issues**, for example:

Closes #123
-->
