### PR TITLE
networkrules: optimize $removeparam to operate directly on url.Values

### DIFF
--- a/networkrules/exceptionrule/exceptionrule.go
+++ b/networkrules/exceptionrule/exceptionrule.go
@@ -15,7 +15,8 @@ type ExceptionRule struct {
 	FilterName *string
 
 	Modifiers          ExceptionModifiers
-	ModifyingModifiers []rulemodifiers.ModifyingModifier
+	ModifyingModifiers []rulemodifiers.ReqResModifier
+	QueryModifiers     []rulemodifiers.QueryModifier
 	Document           bool
 }
 
@@ -35,13 +36,13 @@ func (er *ExceptionRule) Cancels(r *rule.Rule) bool {
 		return false
 	}
 
-	if len(er.Modifiers.AndModifiers) == 0 && len(er.Modifiers.OrModifiers) == 0 && len(er.ModifyingModifiers) == 0 {
+	if len(er.Modifiers.AndModifiers) == 0 && len(er.Modifiers.OrModifiers) == 0 && len(er.ModifyingModifiers) == 0 && len(er.QueryModifiers) == 0 {
 		return true
 	}
 
 	for _, exc := range er.Modifiers.AndModifiers {
 		found := false
-		for _, basic := range r.MatchingModifiers.AndModifiers {
+		for _, basic := range r.MatchingModifiers.And {
 			if exc.Cancels(basic) {
 				found = true
 				break
@@ -55,7 +56,7 @@ func (er *ExceptionRule) Cancels(r *rule.Rule) bool {
 	if len(er.Modifiers.OrModifiers) > 0 {
 		found := false
 		for _, exc := range er.Modifiers.OrModifiers {
-			for _, basic := range r.MatchingModifiers.OrModifiers {
+			for _, basic := range r.MatchingModifiers.Or {
 				if exc.Cancels(basic) {
 					found = true
 					break
@@ -72,7 +73,20 @@ func (er *ExceptionRule) Cancels(r *rule.Rule) bool {
 
 	for _, exc := range er.ModifyingModifiers {
 		found := false
-		for _, basic := range r.ModifyingModifiers {
+		for _, basic := range r.ReqResModifiers {
+			if exc.Cancels(basic) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+
+	for _, exc := range er.QueryModifiers {
+		found := false
+		for _, basic := range r.QueryModifiers {
 			if exc.Cancels(basic) {
 				found = true
 				break
@@ -141,15 +155,18 @@ func (er *ExceptionRule) ParseModifiers(modifiers []string) error {
 			return err
 		}
 
-		if matchingModifier, ok := modifier.(exceptionModifier); ok {
+		switch m := modifier.(type) {
+		case exceptionModifier:
 			if isOr {
-				er.Modifiers.OrModifiers = append(er.Modifiers.OrModifiers, matchingModifier)
+				er.Modifiers.OrModifiers = append(er.Modifiers.OrModifiers, m)
 			} else {
-				er.Modifiers.AndModifiers = append(er.Modifiers.AndModifiers, matchingModifier)
+				er.Modifiers.AndModifiers = append(er.Modifiers.AndModifiers, m)
 			}
-		} else if modifyingModifier, ok := modifier.(rulemodifiers.ModifyingModifier); ok {
-			er.ModifyingModifiers = append(er.ModifyingModifiers, modifyingModifier)
-		} else {
+		case rulemodifiers.ReqResModifier:
+			er.ModifyingModifiers = append(er.ModifyingModifiers, m)
+		case rulemodifiers.QueryModifier:
+			er.QueryModifiers = append(er.QueryModifiers, m)
+		default:
 			panic(fmt.Sprintf("got unknown modifier type %T for modifier %s", modifier, m))
 		}
 

--- a/networkrules/exceptionrule/exceptionrule.go
+++ b/networkrules/exceptionrule/exceptionrule.go
@@ -3,6 +3,7 @@ package exceptionrule
 import (
 	"errors"
 	"fmt"
+	"log"
 	"net/http"
 	"strings"
 
@@ -155,19 +156,19 @@ func (er *ExceptionRule) ParseModifiers(modifiers []string) error {
 			return err
 		}
 
-		switch m := modifier.(type) {
+		switch typed := modifier.(type) {
 		case exceptionModifier:
 			if isOr {
-				er.Modifiers.OrModifiers = append(er.Modifiers.OrModifiers, m)
+				er.Modifiers.OrModifiers = append(er.Modifiers.OrModifiers, typed)
 			} else {
-				er.Modifiers.AndModifiers = append(er.Modifiers.AndModifiers, m)
+				er.Modifiers.AndModifiers = append(er.Modifiers.AndModifiers, typed)
 			}
 		case rulemodifiers.ReqResModifier:
-			er.ReqResModifiers = append(er.ReqResModifiers, m)
+			er.ReqResModifiers = append(er.ReqResModifiers, typed)
 		case rulemodifiers.QueryModifier:
-			er.QueryModifiers = append(er.QueryModifiers, m)
+			er.QueryModifiers = append(er.QueryModifiers, typed)
 		default:
-			panic(fmt.Sprintf("got unknown modifier type %T for modifier %s", modifier, m))
+			log.Fatalf("got unknown modifier type %T for modifier %s", modifier, m)
 		}
 
 	}

--- a/networkrules/exceptionrule/exceptionrule.go
+++ b/networkrules/exceptionrule/exceptionrule.go
@@ -14,10 +14,10 @@ type ExceptionRule struct {
 	RawRule    string
 	FilterName *string
 
-	Modifiers          ExceptionModifiers
-	ModifyingModifiers []rulemodifiers.ReqResModifier
-	QueryModifiers     []rulemodifiers.QueryModifier
-	Document           bool
+	Modifiers       ExceptionModifiers
+	ReqResModifiers []rulemodifiers.ReqResModifier
+	QueryModifiers  []rulemodifiers.QueryModifier
+	Document        bool
 }
 
 type ExceptionModifiers struct {
@@ -36,7 +36,7 @@ func (er *ExceptionRule) Cancels(r *rule.Rule) bool {
 		return false
 	}
 
-	if len(er.Modifiers.AndModifiers) == 0 && len(er.Modifiers.OrModifiers) == 0 && len(er.ModifyingModifiers) == 0 && len(er.QueryModifiers) == 0 {
+	if len(er.Modifiers.AndModifiers) == 0 && len(er.Modifiers.OrModifiers) == 0 && len(er.ReqResModifiers) == 0 && len(er.QueryModifiers) == 0 {
 		return true
 	}
 
@@ -71,7 +71,7 @@ func (er *ExceptionRule) Cancels(r *rule.Rule) bool {
 		}
 	}
 
-	for _, exc := range er.ModifyingModifiers {
+	for _, exc := range er.ReqResModifiers {
 		found := false
 		for _, basic := range r.ReqResModifiers {
 			if exc.Cancels(basic) {
@@ -163,7 +163,7 @@ func (er *ExceptionRule) ParseModifiers(modifiers []string) error {
 				er.Modifiers.AndModifiers = append(er.Modifiers.AndModifiers, m)
 			}
 		case rulemodifiers.ReqResModifier:
-			er.ModifyingModifiers = append(er.ModifyingModifiers, m)
+			er.ReqResModifiers = append(er.ReqResModifiers, m)
 		case rulemodifiers.QueryModifier:
 			er.QueryModifiers = append(er.QueryModifiers, m)
 		default:

--- a/networkrules/networkrules.go
+++ b/networkrules/networkrules.go
@@ -132,6 +132,7 @@ func (nr *NetworkRules) ModifyReq(req *http.Request) (appliedRules []rule.Rule, 
 		query = req.URL.Query()
 	}
 
+	var queryModified bool
 outer:
 	for _, r := range primaryRules {
 		for _, ex := range exceptions {
@@ -145,7 +146,10 @@ outer:
 
 		modified := r.ModifyReq(req)
 		if query != nil {
-			modified = r.ModifyReqQuery(query) || modified
+			if r.ModifyReqQuery(query) {
+				queryModified = true
+				modified = true
+			}
 		}
 
 		if modified {
@@ -153,7 +157,9 @@ outer:
 		}
 	}
 
-	if len(appliedRules) > 0 && query != nil {
+	if queryModified {
+		// Re-encoding the same query params may cause subtle normalization changes
+		// (e.g. parameter reordering), so only do it if they were actually modified.
 		req.URL.RawQuery = query.Encode()
 	}
 

--- a/networkrules/networkrules.go
+++ b/networkrules/networkrules.go
@@ -110,9 +110,9 @@ func (nr *NetworkRules) ParseRule(rawRule string, filterName *string) (isExcepti
 }
 
 func (nr *NetworkRules) ModifyReq(req *http.Request) (appliedRules []rule.Rule, shouldBlock bool, redirectURL string) {
-	url := renderURLWithoutPort(req.URL)
+	reqURL := renderURLWithoutPort(req.URL)
 
-	primaryRules := nr.primaryStore.Get(url)
+	primaryRules := nr.primaryStore.Get(reqURL)
 	primaryRules = filter(primaryRules, func(r *rule.Rule) bool {
 		return r.ShouldMatchReq(req)
 	})
@@ -120,12 +120,18 @@ func (nr *NetworkRules) ModifyReq(req *http.Request) (appliedRules []rule.Rule, 
 		return nil, false, ""
 	}
 
-	exceptions := nr.exceptionStore.Get(url)
+	exceptions := nr.exceptionStore.Get(reqURL)
 	exceptions = filter(exceptions, func(er *exceptionrule.ExceptionRule) bool {
 		return er.ShouldMatchReq(req)
 	})
 
 	initialURL := req.URL.String()
+
+	var query url.Values
+	if req.URL.RawQuery != "" {
+		query = req.URL.Query()
+	}
+
 outer:
 	for _, r := range primaryRules {
 		for _, ex := range exceptions {
@@ -136,9 +142,19 @@ outer:
 		if r.ShouldBlockReq(req) {
 			return []rule.Rule{*r}, true, ""
 		}
-		if r.ModifyReq(req) {
+
+		modified := r.ModifyReq(req)
+		if query != nil {
+			modified = r.ModifyReqQuery(query) || modified
+		}
+
+		if modified {
 			appliedRules = append(appliedRules, *r)
 		}
+	}
+
+	if len(appliedRules) > 0 && query != nil {
+		req.URL.RawQuery = query.Encode()
 	}
 
 	finalURL := req.URL.String()

--- a/networkrules/rule/rule.go
+++ b/networkrules/rule/rule.go
@@ -96,17 +96,17 @@ func (rm *Rule) ParseModifiers(modifiers []string) error {
 			return err
 		}
 
-		switch m := modifier.(type) {
+		switch typed := modifier.(type) {
 		case rulemodifiers.MatchingModifier:
 			if isOr {
-				rm.MatchingModifiers.Or = append(rm.MatchingModifiers.Or, m)
+				rm.MatchingModifiers.Or = append(rm.MatchingModifiers.Or, typed)
 			} else {
-				rm.MatchingModifiers.And = append(rm.MatchingModifiers.And, m)
+				rm.MatchingModifiers.And = append(rm.MatchingModifiers.And, typed)
 			}
 		case rulemodifiers.ReqResModifier:
-			rm.ReqResModifiers = append(rm.ReqResModifiers, m)
+			rm.ReqResModifiers = append(rm.ReqResModifiers, typed)
 		case rulemodifiers.QueryModifier:
-			rm.QueryModifiers = append(rm.QueryModifiers, m)
+			rm.QueryModifiers = append(rm.QueryModifiers, typed)
 		default:
 			log.Fatalf("got unknown modifier type %T for modifier %s", modifier, m)
 		}

--- a/networkrules/rule/rule.go
+++ b/networkrules/rule/rule.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"net/url"
 	"strings"
 
 	"github.com/ZenPrivacy/zen-core/networkrules/rulemodifiers"
@@ -18,18 +19,19 @@ type Rule struct {
 	// FilterName is the name of the filter that the rule belongs to.
 	FilterName *string
 
-	MatchingModifiers  matchingModifiers
-	ModifyingModifiers []rulemodifiers.ModifyingModifier
+	MatchingModifiers matchingModifiers
+	ReqResModifiers   []rulemodifiers.ReqResModifier
+	QueryModifiers    []rulemodifiers.QueryModifier
 
 	// Document shows if rule has Document modifier.
 	Document bool
 }
 
 type matchingModifiers struct {
-	// AndModifiers should be matched together.
-	AndModifiers []rulemodifiers.MatchingModifier
-	// OrModifiers should be matched if one of them is matched.
-	OrModifiers []rulemodifiers.MatchingModifier
+	// And are modifiers that must all match for the rule to apply.
+	And []rulemodifiers.MatchingModifier
+	// Or are modifiers where at least one must match for the rule to apply.
+	Or []rulemodifiers.MatchingModifier
 }
 
 func (rm *Rule) ParseModifiers(modifiers []string) error {
@@ -94,15 +96,18 @@ func (rm *Rule) ParseModifiers(modifiers []string) error {
 			return err
 		}
 
-		if matchingModifier, ok := modifier.(rulemodifiers.MatchingModifier); ok {
+		switch m := modifier.(type) {
+		case rulemodifiers.MatchingModifier:
 			if isOr {
-				rm.MatchingModifiers.OrModifiers = append(rm.MatchingModifiers.OrModifiers, matchingModifier)
+				rm.MatchingModifiers.Or = append(rm.MatchingModifiers.Or, m)
 			} else {
-				rm.MatchingModifiers.AndModifiers = append(rm.MatchingModifiers.AndModifiers, matchingModifier)
+				rm.MatchingModifiers.And = append(rm.MatchingModifiers.And, m)
 			}
-		} else if modifyingModifier, ok := modifier.(rulemodifiers.ModifyingModifier); ok {
-			rm.ModifyingModifiers = append(rm.ModifyingModifiers, modifyingModifier)
-		} else {
+		case rulemodifiers.ReqResModifier:
+			rm.ReqResModifiers = append(rm.ReqResModifiers, m)
+		case rulemodifiers.QueryModifier:
+			rm.QueryModifiers = append(rm.QueryModifiers, m)
+		default:
 			log.Fatalf("got unknown modifier type %T for modifier %s", modifier, m)
 		}
 	}
@@ -117,15 +122,15 @@ func (rm *Rule) ShouldMatchReq(req *http.Request) bool {
 	}
 
 	// AndModifiers: All must match.
-	for _, m := range rm.MatchingModifiers.AndModifiers {
+	for _, m := range rm.MatchingModifiers.And {
 		if !m.ShouldMatchReq(req) {
 			return false
 		}
 	}
 
 	// OrModifiers: At least one must match.
-	if len(rm.MatchingModifiers.OrModifiers) > 0 {
-		for _, m := range rm.MatchingModifiers.OrModifiers {
+	if len(rm.MatchingModifiers.Or) > 0 {
+		for _, m := range rm.MatchingModifiers.Or {
 			if m.ShouldMatchReq(req) {
 				return true
 			}
@@ -139,14 +144,14 @@ func (rm *Rule) ShouldMatchReq(req *http.Request) bool {
 // ShouldMatchRes returns true if the rule should match the response.
 func (rm *Rule) ShouldMatchRes(res *http.Response) bool {
 	// maybe add sec-fetch logic too
-	for _, m := range rm.MatchingModifiers.AndModifiers {
+	for _, m := range rm.MatchingModifiers.And {
 		if !m.ShouldMatchRes(res) {
 			return false
 		}
 	}
 
-	if len(rm.MatchingModifiers.OrModifiers) > 0 {
-		for _, m := range rm.MatchingModifiers.OrModifiers {
+	if len(rm.MatchingModifiers.Or) > 0 {
+		for _, m := range rm.MatchingModifiers.Or {
 			if m.ShouldMatchRes(res) {
 				return true
 			}
@@ -159,13 +164,24 @@ func (rm *Rule) ShouldMatchRes(res *http.Response) bool {
 
 // ShouldBlockReq returns true if the request should be blocked.
 func (rm *Rule) ShouldBlockReq(*http.Request) bool {
-	return len(rm.ModifyingModifiers) == 0
+	return len(rm.ReqResModifiers) == 0 && len(rm.QueryModifiers) == 0
 }
 
 // ModifyReq modifies a request. Returns true if the request was modified.
 func (rm *Rule) ModifyReq(req *http.Request) (modified bool) {
-	for _, modifier := range rm.ModifyingModifiers {
+	for _, modifier := range rm.ReqResModifiers {
 		if modifier.ModifyReq(req) {
+			modified = true
+		}
+	}
+
+	return modified
+}
+
+// ModifyReqQuery modifies a request query. Returns true if the query was modified.
+func (rm *Rule) ModifyReqQuery(query url.Values) (modified bool) {
+	for _, qm := range rm.QueryModifiers {
+		if qm.ModifyQuery(query) {
 			modified = true
 		}
 	}
@@ -175,7 +191,7 @@ func (rm *Rule) ModifyReq(req *http.Request) (modified bool) {
 
 // ModifyRes modifies a response. Returns true if the response was modified.
 func (rm *Rule) ModifyRes(res *http.Response) (modified bool, err error) {
-	for _, modifier := range rm.ModifyingModifiers {
+	for _, modifier := range rm.ReqResModifiers {
 		m, err := modifier.ModifyRes(res)
 		if err != nil {
 			return false, fmt.Errorf("modify response: %w", err)

--- a/networkrules/rulemodifiers/jsonprune.go
+++ b/networkrules/rulemodifiers/jsonprune.go
@@ -16,7 +16,7 @@ type JSONPruneModifier struct {
 	commands []string
 }
 
-var _ ModifyingModifier = (*JSONPruneModifier)(nil)
+var _ ReqResModifier = (*JSONPruneModifier)(nil)
 
 var ErrInvalidJSONPruneModifier = errors.New("invalid jsonprune modifier")
 

--- a/networkrules/rulemodifiers/removeheader.go
+++ b/networkrules/rulemodifiers/removeheader.go
@@ -76,7 +76,7 @@ type RemoveHeaderModifier struct {
 	HeaderName string
 }
 
-var _ ModifyingModifier = (*RemoveHeaderModifier)(nil)
+var _ ReqResModifier = (*RemoveHeaderModifier)(nil)
 
 func (rm *RemoveHeaderModifier) Parse(modifier string) error {
 	if !strings.HasPrefix(modifier, "removeheader=") {

--- a/networkrules/rulemodifiers/removejsconstant/removejsconstant.go
+++ b/networkrules/rulemodifiers/removejsconstant/removejsconstant.go
@@ -20,7 +20,7 @@ type Modifier struct {
 	keys [][]string
 }
 
-var _ rulemodifiers.ModifyingModifier = (*Modifier)(nil)
+var _ rulemodifiers.ReqResModifier = (*Modifier)(nil)
 
 var removeJSConstantRegex = regexp.MustCompile(`^remove-js-constant=(.*)$`)
 
@@ -38,7 +38,7 @@ func (rc *Modifier) Parse(modifier string) error {
 	return nil
 }
 
-// ModifyReq implements [rulemodifiers.ModifyingModifier].
+// ModifyReq implements [rulemodifiers.ReqResModifier].
 func (*Modifier) ModifyReq(*http.Request) bool {
 	return false
 }

--- a/networkrules/rulemodifiers/removeparam.go
+++ b/networkrules/rulemodifiers/removeparam.go
@@ -76,9 +76,7 @@ func (rm *RemoveParamModifier) ModifyQuery(query url.Values) bool {
 	var modified bool
 	switch rm.kind {
 	case removeparamKindGeneric:
-		for param := range query {
-			query.Del(param)
-		}
+		clear(query)
 		modified = true
 	case removeparamKindRegexp:
 		for param, values := range query {

--- a/networkrules/rulemodifiers/removeparam.go
+++ b/networkrules/rulemodifiers/removeparam.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 )
 
-type removeparamKind int
+type removeparamKind int8
 
 const (
 	removeparamKindGeneric removeparamKind = iota
@@ -78,8 +78,8 @@ func (rm *RemoveParamModifier) ModifyQuery(query url.Values) bool {
 	case removeparamKindGeneric:
 		for param := range query {
 			query.Del(param)
-			modified = true
 		}
+		modified = true
 	case removeparamKindRegexp:
 		for param, values := range query {
 			filtered := values[:0]

--- a/networkrules/rulemodifiers/removeparam.go
+++ b/networkrules/rulemodifiers/removeparam.go
@@ -3,12 +3,12 @@ package rulemodifiers
 import (
 	"errors"
 	"fmt"
-	"net/http"
+	"net/url"
 	"regexp"
 	"strings"
 )
 
-type removeparamKind int8
+type removeparamKind int
 
 const (
 	removeparamKindGeneric removeparamKind = iota
@@ -24,7 +24,7 @@ type RemoveParamModifier struct {
 	regexp *regexp.Regexp
 }
 
-var _ ModifyingModifier = (*RemoveParamModifier)(nil)
+var _ QueryModifier = (*RemoveParamModifier)(nil)
 
 func (rm *RemoveParamModifier) Parse(modifier string) error {
 	if modifier == "removeparam" {
@@ -68,9 +68,12 @@ func (rm *RemoveParamModifier) Parse(modifier string) error {
 	return nil
 }
 
-func (rm *RemoveParamModifier) ModifyReq(req *http.Request) (modified bool) {
-	query := req.URL.Query()
+func (rm *RemoveParamModifier) ModifyQuery(query url.Values) bool {
+	if len(query) == 0 {
+		return false
+	}
 
+	var modified bool
 	switch rm.kind {
 	case removeparamKindGeneric:
 		for param := range query {
@@ -119,15 +122,7 @@ func (rm *RemoveParamModifier) ModifyReq(req *http.Request) (modified bool) {
 		}
 	}
 
-	if modified {
-		req.URL.RawQuery = query.Encode()
-	}
 	return modified
-}
-
-// ModifyRes implements [ModifyingModifier].
-func (rm *RemoveParamModifier) ModifyRes(*http.Response) (modified bool, err error) {
-	return false, nil
 }
 
 func (rm *RemoveParamModifier) Cancels(modifier Modifier) bool {

--- a/networkrules/rulemodifiers/removeparam_test.go
+++ b/networkrules/rulemodifiers/removeparam_test.go
@@ -1,7 +1,7 @@
 package rulemodifiers
 
 import (
-	"net/http"
+	"net/url"
 	"regexp"
 	"testing"
 )
@@ -98,17 +98,23 @@ func TestRemoveParamModifier(t *testing.T) {
 			t.Run(tt.name, func(t *testing.T) {
 				t.Parallel()
 
-				req, err := http.NewRequest("GET", tt.url, nil)
+				u, err := url.Parse(tt.url)
 				if err != nil {
-					t.Fatalf("Failed to create request: %v", err)
+					t.Fatalf("parse URL %q: %v", tt.url, err)
 				}
 
-				modified := tt.modifier.ModifyReq(req)
+				q := u.Query()
+
+				modified := tt.modifier.ModifyQuery(q)
 				if modified != tt.modified {
 					t.Errorf("ModifyReq() modified = %v, want %v", modified, tt.modified)
 				}
 
-				got := req.URL.String()
+				if modified {
+					u.RawQuery = q.Encode()
+				}
+
+				got := u.String()
 				if got != tt.want {
 					t.Errorf("ModifyReq() got URL = %v, want %v", got, tt.want)
 				}

--- a/networkrules/rulemodifiers/rulemodifiers.go
+++ b/networkrules/rulemodifiers/rulemodifiers.go
@@ -2,24 +2,31 @@ package rulemodifiers
 
 import (
 	"net/http"
+	"net/url"
 )
 
 // Modifier is a Modifier of a rule.
 type Modifier interface {
-	Parse(modifier string) error
+	Parse(string) error
+	Cancels(Modifier) bool
 }
 
 // MatchingModifier defines whether a rule matches a request.
 type MatchingModifier interface {
 	Modifier
-	ShouldMatchReq(req *http.Request) bool
-	ShouldMatchRes(res *http.Response) bool
+	ShouldMatchReq(*http.Request) bool
+	ShouldMatchRes(*http.Response) bool
 }
 
-// modifyingModifier modifies a request.
-type ModifyingModifier interface {
+// ReqResModifier modifies requests and responses.
+type ReqResModifier interface {
 	Modifier
-	ModifyReq(req *http.Request) (modified bool)
-	ModifyRes(res *http.Response) (modified bool, err error)
-	Cancels(Modifier) bool
+	ModifyReq(*http.Request) bool
+	ModifyRes(*http.Response) (bool, error)
+}
+
+// QueryModifier modifies request query parameters.
+type QueryModifier interface {
+	Modifier
+	ModifyQuery(url.Values) bool
 }

--- a/networkrules/rulemodifiers/scramblejs.go
+++ b/networkrules/rulemodifiers/scramblejs.go
@@ -19,7 +19,7 @@ type ScrambleJSModifier struct {
 	keys []*regexp.Regexp
 }
 
-var _ ModifyingModifier = (*ScrambleJSModifier)(nil)
+var _ ReqResModifier = (*ScrambleJSModifier)(nil)
 
 var scrambleJSRegex = regexp.MustCompile(`^scramblejs=(.+)$`)
 


### PR DESCRIPTION
### What does this PR do?

`RemoveParamModifier` used to repeatedly call `req.URL.Query()` on the same URL. The method doesn't have any internal caching, so each call parses the query from scratch. This led to `url.parseQuery` being the top 1 function in CPU time, as shown by profiling:

<img width="862" height="97" alt="image" src="https://github.com/user-attachments/assets/432c82e8-b6d3-47c5-9753-9312ba067549" />

Beyond CPU load, the method puts a lot of GC pressure due to internal allocations.

To optimize that, this PR refactors the package to introduce `rulemodifiers.QueryModifier` that operate directly on `url.Values` without parsing overhead.


### How did you verify your code works?

Existing unit tests. Manual testing.

### What are the relevant issues?

<!--
**Please link any relevant issues**, for example:

Closes #123
-->
