### PR TITLE
Emit process data from filter

### DIFF
--- a/filter/filter.go
+++ b/filter/filter.go
@@ -18,8 +18,8 @@ import (
 	"github.com/ZenPrivacy/zen-core/process"
 )
 
-// filterEventsEmitter emits filter events.
-type filterEventsEmitter interface {
+// filterActionObserver observes filter events.
+type filterActionObserver interface {
 	OnFilterBlock(method, url, referer string, rules []rule.Rule, process process.Process)
 	OnFilterRedirect(method, url, to, referer string, rules []rule.Rule, proc process.Process)
 	OnFilterModify(method, url, referer string, rules []rule.Rule, proc process.Process)
@@ -56,7 +56,7 @@ type Filter struct {
 	networkRules    networkRules
 	injector        documentInjector
 	filterListStore filterListStore
-	eventsEmitter   filterEventsEmitter
+	actionObserver  filterActionObserver
 	whitelistSrv    whitelistSrv
 }
 
@@ -66,9 +66,9 @@ var (
 )
 
 // NewFilter creates and initializes a new filter.
-func NewFilter(networkRules networkRules, injector documentInjector, filterListStore filterListStore, eventsEmitter filterEventsEmitter, whitelistSrv whitelistSrv) (*Filter, error) {
-	if eventsEmitter == nil {
-		return nil, errors.New("eventsEmitter is nil")
+func NewFilter(networkRules networkRules, injector documentInjector, filterListStore filterListStore, actionObserver filterActionObserver, whitelistSrv whitelistSrv) (*Filter, error) {
+	if actionObserver == nil {
+		return nil, errors.New("actionObserver is nil")
 	}
 	if networkRules == nil {
 		return nil, errors.New("networkRules is nil")
@@ -86,7 +86,7 @@ func NewFilter(networkRules networkRules, injector documentInjector, filterListS
 	f := &Filter{
 		networkRules:    networkRules,
 		injector:        injector,
-		eventsEmitter:   eventsEmitter,
+		actionObserver:  actionObserver,
 		whitelistSrv:    whitelistSrv,
 		filterListStore: filterListStore,
 	}
@@ -236,7 +236,7 @@ func (f *Filter) HandleRequest(req *http.Request, proc process.Process) (*http.R
 
 	appliedRules, shouldBlock, redirectURL := f.networkRules.ModifyReq(req)
 	if shouldBlock {
-		f.eventsEmitter.OnFilterBlock(req.Method, initialURL, req.Header.Get("Referer"), appliedRules, proc)
+		f.actionObserver.OnFilterBlock(req.Method, initialURL, req.Header.Get("Referer"), appliedRules, proc)
 
 		if isUserNavigation(req) {
 			port := f.whitelistSrv.GetPort()
@@ -255,12 +255,12 @@ func (f *Filter) HandleRequest(req *http.Request, proc process.Process) (*http.R
 	}
 
 	if redirectURL != "" {
-		f.eventsEmitter.OnFilterRedirect(req.Method, initialURL, redirectURL, req.Header.Get("Referer"), appliedRules, proc)
+		f.actionObserver.OnFilterRedirect(req.Method, initialURL, redirectURL, req.Header.Get("Referer"), appliedRules, proc)
 		return f.networkRules.CreateRedirectResponse(req, redirectURL), nil
 	}
 
 	if len(appliedRules) > 0 {
-		f.eventsEmitter.OnFilterModify(req.Method, initialURL, req.Header.Get("Referer"), appliedRules, proc)
+		f.actionObserver.OnFilterModify(req.Method, initialURL, req.Header.Get("Referer"), appliedRules, proc)
 	}
 
 	return nil, nil
@@ -292,7 +292,7 @@ func (f *Filter) HandleResponse(req *http.Request, res *http.Response, proc proc
 		return fmt.Errorf("apply network rules: %v", err)
 	}
 	if len(appliedRules) > 0 {
-		f.eventsEmitter.OnFilterModify(req.Method, req.URL.String(), req.Header.Get("Referer"), appliedRules, proc)
+		f.actionObserver.OnFilterModify(req.Method, req.URL.String(), req.Header.Get("Referer"), appliedRules, proc)
 	}
 
 	return nil

--- a/filter/filter.go
+++ b/filter/filter.go
@@ -15,13 +15,14 @@ import (
 
 	"github.com/ZenPrivacy/zen-core/internal/redacted"
 	"github.com/ZenPrivacy/zen-core/networkrules/rule"
+	"github.com/ZenPrivacy/zen-core/process"
 )
 
 // filterEventsEmitter emits filter events.
 type filterEventsEmitter interface {
-	OnFilterBlock(method, url, referer string, rules []rule.Rule)
-	OnFilterRedirect(method, url, to, referer string, rules []rule.Rule)
-	OnFilterModify(method, url, referer string, rules []rule.Rule)
+	OnFilterBlock(method, url, referer string, rules []rule.Rule, process process.Process)
+	OnFilterRedirect(method, url, to, referer string, rules []rule.Rule, proc process.Process)
+	OnFilterModify(method, url, referer string, rules []rule.Rule, proc process.Process)
 }
 
 type filterListStore interface {
@@ -230,12 +231,12 @@ func (f *Filter) addRule(rule string, filterListName *string, filterListTrusted 
 
 // HandleRequest handles the given request by matching it against the filter rules.
 // If the request should be blocked, it returns a response that blocks the request. If the request should be modified, it modifies it in-place.
-func (f *Filter) HandleRequest(req *http.Request) (*http.Response, error) {
+func (f *Filter) HandleRequest(req *http.Request, proc process.Process) (*http.Response, error) {
 	initialURL := req.URL.String()
 
 	appliedRules, shouldBlock, redirectURL := f.networkRules.ModifyReq(req)
 	if shouldBlock {
-		f.eventsEmitter.OnFilterBlock(req.Method, initialURL, req.Header.Get("Referer"), appliedRules)
+		f.eventsEmitter.OnFilterBlock(req.Method, initialURL, req.Header.Get("Referer"), appliedRules, proc)
 
 		if isUserNavigation(req) {
 			port := f.whitelistSrv.GetPort()
@@ -254,12 +255,12 @@ func (f *Filter) HandleRequest(req *http.Request) (*http.Response, error) {
 	}
 
 	if redirectURL != "" {
-		f.eventsEmitter.OnFilterRedirect(req.Method, initialURL, redirectURL, req.Header.Get("Referer"), appliedRules)
+		f.eventsEmitter.OnFilterRedirect(req.Method, initialURL, redirectURL, req.Header.Get("Referer"), appliedRules, proc)
 		return f.networkRules.CreateRedirectResponse(req, redirectURL), nil
 	}
 
 	if len(appliedRules) > 0 {
-		f.eventsEmitter.OnFilterModify(req.Method, initialURL, req.Header.Get("Referer"), appliedRules)
+		f.eventsEmitter.OnFilterModify(req.Method, initialURL, req.Header.Get("Referer"), appliedRules, proc)
 	}
 
 	return nil, nil
@@ -278,7 +279,7 @@ func (f *Filter) Finalize() {
 //
 // As of April 2024, there are no response-only rules that can block or redirect responses.
 // For that reason, this method does not return a blocking or redirecting response itself.
-func (f *Filter) HandleResponse(req *http.Request, res *http.Response) error {
+func (f *Filter) HandleResponse(req *http.Request, res *http.Response, proc process.Process) error {
 	if isDocumentNavigation(req, res) {
 		if err := f.injector.Inject(req, res); err != nil {
 			// This injection error is recoverable, so we log it and continue processing the response.
@@ -291,7 +292,7 @@ func (f *Filter) HandleResponse(req *http.Request, res *http.Response) error {
 		return fmt.Errorf("apply network rules: %v", err)
 	}
 	if len(appliedRules) > 0 {
-		f.eventsEmitter.OnFilterModify(req.Method, req.URL.String(), req.Header.Get("Referer"), appliedRules)
+		f.eventsEmitter.OnFilterModify(req.Method, req.URL.String(), req.Header.Get("Referer"), appliedRules, proc)
 	}
 
 	return nil

--- a/process/process_darwin.go
+++ b/process/process_darwin.go
@@ -16,9 +16,9 @@ import "C"
 
 import "fmt"
 
-// ProcPathMaxsize sets the buffer length for proc_name. It's not defined
+// procPathMaxsize sets the buffer length for proc_name. It's not defined
 // in libproc.h, and various codebases use values from 64 to 4096, but 1024 is likely ok.
-const ProcPathMaxsize = 1024
+const procPathMaxsize = 1024
 
 // FindBySourcePort returns the process that owns the given TCP/IPv4 source port,
 // or ErrNotFound if no process owns it.
@@ -42,7 +42,7 @@ func FindBySourcePort(port uint16) (Process, error) {
 	}
 	p.DiskPath = C.GoString(&pathBuf[0])
 
-	var nameBuf [ProcPathMaxsize]C.char
+	var nameBuf [procPathMaxsize]C.char
 	ret = C.find_process_name_by_pid(pid, &nameBuf[0], C.size_t(len(nameBuf)))
 	if ret < 0 {
 		return Process{}, fmt.Errorf("find name for pid %d: %s", pid, C.GoString(C.strerror(-ret)))

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -12,11 +12,13 @@ import (
 	"net/http"
 	"net/http/httptrace"
 	"net/textproto"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
 
 	"github.com/ZenPrivacy/zen-core/internal/redacted"
+	"github.com/ZenPrivacy/zen-core/process"
 )
 
 // certGenerator is an interface capable of generating certificates for the proxy.
@@ -26,8 +28,8 @@ type certGenerator interface {
 
 // filter is an interface capable of filtering HTTP requests.
 type filter interface {
-	HandleRequest(*http.Request) (*http.Response, error)
-	HandleResponse(*http.Request, *http.Response) error
+	HandleRequest(*http.Request, process.Process) (*http.Response, error)
+	HandleResponse(*http.Request, *http.Response, process.Process) error
 }
 
 // Proxy is a forward HTTP/HTTPS proxy that can filter requests.
@@ -133,16 +135,21 @@ func (p *Proxy) shutdownServer() error {
 }
 
 func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	proc, err := findRequestProcess(r)
+	if err != nil {
+		log.Printf("error finding request process: %v", err)
+	}
+
 	if r.Method == http.MethodConnect {
-		p.proxyConnect(w, r)
+		p.proxyConnect(w, r, proc)
 	} else {
-		p.proxyHTTP(w, r)
+		p.proxyHTTP(w, r, proc)
 	}
 }
 
 // proxyHTTP proxies the HTTP request to the remote server.
-func (p *Proxy) proxyHTTP(w http.ResponseWriter, r *http.Request) {
-	filterResp, err := p.filter.HandleRequest(r)
+func (p *Proxy) proxyHTTP(w http.ResponseWriter, r *http.Request, proc process.Process) {
+	filterResp, err := p.filter.HandleRequest(r, proc)
 	if err != nil {
 		log.Printf("error handling request for %q: %v", redacted.Redacted(r.URL), err)
 	}
@@ -212,7 +219,7 @@ func (p *Proxy) proxyHTTP(w http.ResponseWriter, r *http.Request) {
 
 	removeHopHeaders(resp.Header)
 
-	if err := p.filter.HandleResponse(r, resp); err != nil {
+	if err := p.filter.HandleResponse(r, resp, proc); err != nil {
 		log.Printf("error handling response by filter: %v", err)
 		http.Error(w, err.Error(), http.StatusBadGateway)
 		return
@@ -223,7 +230,7 @@ func (p *Proxy) proxyHTTP(w http.ResponseWriter, r *http.Request) {
 
 // proxyConnect proxies the initial CONNECT and subsequent data between the
 // client and the remote server.
-func (p *Proxy) proxyConnect(w http.ResponseWriter, connReq *http.Request) {
+func (p *Proxy) proxyConnect(w http.ResponseWriter, connReq *http.Request, proc process.Process) {
 	hj, ok := w.(http.Hijacker)
 	if !ok {
 		log.Fatal("http server does not support hijacking")
@@ -284,7 +291,7 @@ func (p *Proxy) proxyConnect(w http.ResponseWriter, connReq *http.Request) {
 	ln := newSingleConnListener(tlsConn)
 
 	srv := &http.Server{
-		Handler:   p.connectHandler(connReq, host, ln),
+		Handler:   p.connectHandler(connReq, host, ln, proc),
 		TLSConfig: tlsConfig,
 		ConnState: func(_ net.Conn, state http.ConnState) {
 			if state == http.StateClosed {
@@ -300,7 +307,7 @@ func (p *Proxy) proxyConnect(w http.ResponseWriter, connReq *http.Request) {
 }
 
 // connectHandler returns an http.Handler that processes requests on a CONNECT-tunnelled TLS connection.
-func (p *Proxy) connectHandler(connReq *http.Request, host string, ln *singleConnListener) http.Handler {
+func (p *Proxy) connectHandler(connReq *http.Request, host string, ln *singleConnListener, proc process.Process) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		req.URL.Host = connReq.Host
 		req.URL.Scheme = "https"
@@ -329,7 +336,7 @@ func (p *Proxy) connectHandler(connReq *http.Request, host string, ln *singleCon
 			req.Header.Set("User-Agent", "")
 		}
 
-		filterResp, err := p.filter.HandleRequest(req)
+		filterResp, err := p.filter.HandleRequest(req, proc)
 		if err != nil {
 			log.Printf("handling request for %q: %v", redacted.Redacted(req.URL), err)
 		}
@@ -389,7 +396,7 @@ func (p *Proxy) connectHandler(connReq *http.Request, host string, ln *singleCon
 
 		removeHopHeaders(resp.Header)
 
-		if err := p.filter.HandleResponse(req, resp); err != nil {
+		if err := p.filter.HandleResponse(req, resp, proc); err != nil {
 			log.Printf("error handling response by filter for %q: %v", redacted.Redacted(req.URL), err)
 			http.Error(w, err.Error(), http.StatusBadGateway)
 			return
@@ -601,4 +608,17 @@ func removeHopHeaders(header http.Header) {
 	for _, h := range hopHeaders {
 		header.Del(h)
 	}
+}
+
+func findRequestProcess(r *http.Request) (process.Process, error) {
+	_, sourcePort, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		return process.Process{}, fmt.Errorf("parse RemoteAddr: %v", err)
+	}
+	sourcePortNum, err := strconv.ParseUint(sourcePort, 10, 16)
+	if err != nil {
+		return process.Process{}, fmt.Errorf("parse source port: %v", err)
+	}
+
+	return process.FindBySourcePort(uint16(sourcePortNum))
 }


### PR DESCRIPTION
### What does this PR do?

- Adds process finding on incoming events to `proxy`.
- Outputs process data in `filter`'s `actionObserver` methods (previously `eventsEmitter`).

### How did you verify your code works?

Updates ZenPrivacy/zen-desktop#70

### What are the relevant issues?

<!--
**Please link any relevant issues**, for example:

Closes #123
-->
