### PR TITLE
Rename ZenPrivacy links and imports to irbis-sh/irbis.sh

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,6 +1,6 @@
 # Code of Conduct
 
-This project follows the [Zen Privacy Community Code of Conduct](https://github.com/ZenPrivacy/community/blob/main/CODE_OF_CONDUCT.md).
+This project follows the [Zen Privacy Community Code of Conduct](https://github.com/irbis-sh/community/blob/main/CODE_OF_CONDUCT.md).
 
 By participating in this repository and its associated social spaces, you agree to abide by the standards and expectations outlined in the community-wide Code of Conduct. These guidelines are in place to foster a respectful, inclusive, and collaborative environment for everyone involved in Zen Privacy projects.
 

--- a/COPYING.md
+++ b/COPYING.md
@@ -5,7 +5,7 @@
 `zen-core`, including its source code and all attached documentation, is licensed under the MIT License.
 
 ```
-Copyright (c) 2025 Zen Project Developers
+Copyright (c) 2025-Present Irbis & Zen contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/COPYING.md
+++ b/COPYING.md
@@ -28,7 +28,7 @@ SOFTWARE.
 
 ## 3rd party code and assets
 
-Some code and other assets used in `zen-core` are licensed under different terms. This section attempts to attribute some of them. If you believe that your work is used in `zen-core` without proper attribution, please open an issue or contact us at [contact@zenprivacy.net](mailto:contact@zenprivacy.net).
+Some code and other assets used in `zen-core` are licensed under different terms. This section attempts to attribute some of them. If you believe that your work is used in `zen-core` without proper attribution, please open an issue or contact us at [contact@irbis.sh](mailto:contact@irbis.sh).
 
 ### mkcert
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Zen Project Developers
+Copyright (c) 2025-Present Irbis & Zen contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # zen-core
 
-![License (MIT)](https://img.shields.io/github/license/ZenPrivacy/zen-core)
-![Latest version (git tag)](https://img.shields.io/github/v/tag/ZenPrivacy/zen-core?label=version)
+![License (MIT)](https://img.shields.io/github/license/irbis-sh/zen-core)
+![Latest version (git tag)](https://img.shields.io/github/v/tag/irbis-sh/zen-core?label=version)
 <a href="https://discord.gg/zGeQVatAUm">
 <img alt="Discord" src="https://img.shields.io/discord/1334633399490711685?logo=discord&logoColor=fff&label=Discord&color=5865F2"/>
 </a>

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,11 +2,11 @@
 
 ## Supported Versions
 
-Only the [latest version](https://github.com/ZenPrivacy/zen-core/releases/latest) of the library is actively supported.
+Only the [latest version](https://github.com/irbis-sh/zen-core/releases/latest) of the library is actively supported.
 
 ## Reporting a Vulnerability
 
-If you've discovered a security issue in zen-core, please disclose it privately and responsibly by emailing us at <security@zenprivacy.net>.
+If you've discovered a security issue in zen-core, please disclose it privately and responsibly by emailing us at <security@irbis.sh>.
 
 In your report, please include:
 

--- a/asset/engine.go
+++ b/asset/engine.go
@@ -8,13 +8,13 @@ import (
 	"net/url"
 	"strconv"
 
-	"github.com/ZenPrivacy/zen-core/csp"
-	"github.com/ZenPrivacy/zen-core/httprewrite"
-	"github.com/ZenPrivacy/zen-core/internal/asset/cosmetic"
-	"github.com/ZenPrivacy/zen-core/internal/asset/cssrule"
-	"github.com/ZenPrivacy/zen-core/internal/asset/extendedcss"
-	"github.com/ZenPrivacy/zen-core/internal/asset/jsrule"
-	"github.com/ZenPrivacy/zen-core/internal/asset/scriptlet"
+	"github.com/irbis-sh/zen-core/csp"
+	"github.com/irbis-sh/zen-core/httprewrite"
+	"github.com/irbis-sh/zen-core/internal/asset/cosmetic"
+	"github.com/irbis-sh/zen-core/internal/asset/cssrule"
+	"github.com/irbis-sh/zen-core/internal/asset/extendedcss"
+	"github.com/irbis-sh/zen-core/internal/asset/jsrule"
+	"github.com/irbis-sh/zen-core/internal/asset/scriptlet"
 )
 
 const (

--- a/csp/meta.go
+++ b/csp/meta.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/ZenPrivacy/zen-core/httprewrite"
+	"github.com/irbis-sh/zen-core/httprewrite"
 	"golang.org/x/net/html"
 	"golang.org/x/net/html/atom"
 )

--- a/filter/filter.go
+++ b/filter/filter.go
@@ -13,9 +13,9 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/ZenPrivacy/zen-core/internal/redacted"
-	"github.com/ZenPrivacy/zen-core/networkrules/rule"
-	"github.com/ZenPrivacy/zen-core/process"
+	"github.com/irbis-sh/zen-core/internal/redacted"
+	"github.com/irbis-sh/zen-core/networkrules/rule"
+	"github.com/irbis-sh/zen-core/process"
 )
 
 // filterActionObserver observes filter events.

--- a/filterliststore/filterliststore.go
+++ b/filterliststore/filterliststore.go
@@ -11,7 +11,7 @@ import (
 	"regexp"
 	"time"
 
-	"github.com/ZenPrivacy/zen-core/filterliststore/diskcache"
+	"github.com/irbis-sh/zen-core/filterliststore/diskcache"
 )
 
 const defaultExpiry = 24 * time.Hour

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/ZenPrivacy/zen-core
+module github.com/irbis-sh/zen-core
 
 go 1.25.3
 

--- a/httprewrite/html_test.go
+++ b/httprewrite/html_test.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/ZenPrivacy/zen-core/httprewrite"
+	"github.com/irbis-sh/zen-core/httprewrite"
 )
 
 func TestAppendHTMLHeadContentsPublic(t *testing.T) {

--- a/internal/asset/cosmetic/cosmetic.go
+++ b/internal/asset/cosmetic/cosmetic.go
@@ -3,7 +3,7 @@ package cosmetic
 import (
 	"regexp"
 
-	"github.com/ZenPrivacy/zen-core/internal/asset/extendedcss"
+	"github.com/irbis-sh/zen-core/internal/asset/extendedcss"
 )
 
 var (

--- a/internal/asset/cosmetic/injector.go
+++ b/internal/asset/cosmetic/injector.go
@@ -7,8 +7,8 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/ZenPrivacy/zen-core/internal/hostmatch"
-	"github.com/ZenPrivacy/zen-core/internal/redacted"
+	"github.com/irbis-sh/zen-core/internal/hostmatch"
+	"github.com/irbis-sh/zen-core/internal/redacted"
 )
 
 var (

--- a/internal/asset/cssrule/injector.go
+++ b/internal/asset/cssrule/injector.go
@@ -7,8 +7,8 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/ZenPrivacy/zen-core/internal/hostmatch"
-	"github.com/ZenPrivacy/zen-core/internal/redacted"
+	"github.com/irbis-sh/zen-core/internal/hostmatch"
+	"github.com/irbis-sh/zen-core/internal/redacted"
 )
 
 var (

--- a/internal/asset/extendedcss/injector.go
+++ b/internal/asset/extendedcss/injector.go
@@ -10,8 +10,8 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/ZenPrivacy/zen-core/internal/hostmatch"
-	"github.com/ZenPrivacy/zen-core/internal/redacted"
+	"github.com/irbis-sh/zen-core/internal/hostmatch"
+	"github.com/irbis-sh/zen-core/internal/redacted"
 )
 
 var (

--- a/internal/asset/jsrule/injector.go
+++ b/internal/asset/jsrule/injector.go
@@ -6,8 +6,8 @@ import (
 	"log"
 	"regexp"
 
-	"github.com/ZenPrivacy/zen-core/internal/hostmatch"
-	"github.com/ZenPrivacy/zen-core/internal/redacted"
+	"github.com/irbis-sh/zen-core/internal/hostmatch"
+	"github.com/irbis-sh/zen-core/internal/redacted"
 )
 
 type store interface {

--- a/internal/asset/scriptlet/injector.go
+++ b/internal/asset/scriptlet/injector.go
@@ -7,8 +7,8 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/ZenPrivacy/zen-core/internal/hostmatch"
-	"github.com/ZenPrivacy/zen-core/internal/redacted"
+	"github.com/irbis-sh/zen-core/internal/hostmatch"
+	"github.com/irbis-sh/zen-core/internal/redacted"
 )
 
 var (

--- a/internal/hostmatch/hostmatcher_test.go
+++ b/internal/hostmatch/hostmatcher_test.go
@@ -3,7 +3,7 @@ package hostmatch_test
 import (
 	"testing"
 
-	"github.com/ZenPrivacy/zen-core/internal/hostmatch"
+	"github.com/irbis-sh/zen-core/internal/hostmatch"
 )
 
 func TestHostMatcherPublic(t *testing.T) {

--- a/internal/ruletree/node.go
+++ b/internal/ruletree/node.go
@@ -4,7 +4,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/ZenPrivacy/zen-core/internal/ruletree/byteset"
+	"github.com/irbis-sh/zen-core/internal/ruletree/byteset"
 )
 
 type litEdge[T Data] struct {

--- a/internal/ruletree/ruletree.go
+++ b/internal/ruletree/ruletree.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/ZenPrivacy/zen-core/internal/ruletree/byteset"
+	"github.com/irbis-sh/zen-core/internal/ruletree/byteset"
 )
 
 type Data comparable

--- a/internal/ruletree/ruletree_benchmark_test.go
+++ b/internal/ruletree/ruletree_benchmark_test.go
@@ -36,7 +36,7 @@ import (
 	"runtime"
 	"testing"
 
-	"github.com/ZenPrivacy/zen-core/internal/ruletree"
+	"github.com/irbis-sh/zen-core/internal/ruletree"
 )
 
 const baseSeed = 42

--- a/jslibs/scriptlets/src/set-constant.ts
+++ b/jslibs/scriptlets/src/set-constant.ts
@@ -164,7 +164,7 @@ export function setConstant(
       ) {
         // Native functions frequently expect to be bounded to their original, **unproxied** object.
         // See https://stackoverflow.com/a/57580096 for more details.
-        // Fixes https://github.com/ZenPrivacy/zen-desktop/issues/201
+        // Fixes https://github.com/irbis-sh/zen-desktop/issues/201
         if (boundFnCache !== undefined && boundFnCache[key]) {
           // Like with proxyCache, store the bound function to ensure object equality between different access operations.
           link = boundFnCache[key];
@@ -182,7 +182,7 @@ export function setConstant(
 
       if (proxyCache?.link === link) {
         // Ensure object equality between different access operations.
-        // Fixes https://github.com/ZenPrivacy/zen-desktop/issues/224
+        // Fixes https://github.com/irbis-sh/zen-desktop/issues/224
         return proxyCache.proxy;
       }
       const proxy = new Proxy(link, {
@@ -238,7 +238,7 @@ export function setConstant(
           }
           if (proxyCache?.capturedValue === capturedValue) {
             // Ensure object equality between different access operations.
-            // Fixes https://github.com/ZenPrivacy/zen-desktop/issues/224
+            // Fixes https://github.com/irbis-sh/zen-desktop/issues/224
             return proxyCache.proxy;
           }
           const proxy = new Proxy(capturedValue, {

--- a/networkrules/exceptionrule/exceptionrule.go
+++ b/networkrules/exceptionrule/exceptionrule.go
@@ -7,8 +7,8 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/ZenPrivacy/zen-core/networkrules/rule"
-	"github.com/ZenPrivacy/zen-core/networkrules/rulemodifiers"
+	"github.com/irbis-sh/zen-core/networkrules/rule"
+	"github.com/irbis-sh/zen-core/networkrules/rulemodifiers"
 )
 
 type ExceptionRule struct {

--- a/networkrules/exceptionrule/exceptionrule_test.go
+++ b/networkrules/exceptionrule/exceptionrule_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/ZenPrivacy/zen-core/networkrules/rule"
+	"github.com/irbis-sh/zen-core/networkrules/rule"
 )
 
 func TestExceptionRule(t *testing.T) {

--- a/networkrules/networkrules.go
+++ b/networkrules/networkrules.go
@@ -7,9 +7,9 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/ZenPrivacy/zen-core/internal/ruletree"
-	"github.com/ZenPrivacy/zen-core/networkrules/exceptionrule"
-	"github.com/ZenPrivacy/zen-core/networkrules/rule"
+	"github.com/irbis-sh/zen-core/internal/ruletree"
+	"github.com/irbis-sh/zen-core/networkrules/exceptionrule"
+	"github.com/irbis-sh/zen-core/networkrules/rule"
 )
 
 var (

--- a/networkrules/response.go
+++ b/networkrules/response.go
@@ -8,7 +8,7 @@ import (
 	"io"
 	"net/http"
 
-	"github.com/ZenPrivacy/zen-core/networkrules/rule"
+	"github.com/irbis-sh/zen-core/networkrules/rule"
 )
 
 // CreateBlockResponse creates a response for a blocked request.

--- a/networkrules/rule/rule.go
+++ b/networkrules/rule/rule.go
@@ -8,8 +8,8 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/ZenPrivacy/zen-core/networkrules/rulemodifiers"
-	"github.com/ZenPrivacy/zen-core/networkrules/rulemodifiers/removejsconstant"
+	"github.com/irbis-sh/zen-core/networkrules/rulemodifiers"
+	"github.com/irbis-sh/zen-core/networkrules/rulemodifiers/removejsconstant"
 )
 
 // Rule represents modifiers of a rule.

--- a/networkrules/rulemodifiers/jsonprune.go
+++ b/networkrules/rulemodifiers/jsonprune.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/ZenPrivacy/zen-core/httprewrite"
+	"github.com/irbis-sh/zen-core/httprewrite"
 	"github.com/spyzhov/ajson"
 )
 

--- a/networkrules/rulemodifiers/removejsconstant/removejsconstant.go
+++ b/networkrules/rulemodifiers/removejsconstant/removejsconstant.go
@@ -11,8 +11,8 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/ZenPrivacy/zen-core/httprewrite"
-	"github.com/ZenPrivacy/zen-core/networkrules/rulemodifiers"
+	"github.com/irbis-sh/zen-core/httprewrite"
+	"github.com/irbis-sh/zen-core/networkrules/rulemodifiers"
 	"golang.org/x/net/html"
 )
 

--- a/networkrules/rulemodifiers/scramblejs.go
+++ b/networkrules/rulemodifiers/scramblejs.go
@@ -11,7 +11,7 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/ZenPrivacy/zen-core/httprewrite"
+	"github.com/irbis-sh/zen-core/httprewrite"
 	"golang.org/x/net/html"
 )
 

--- a/networkrules/splitmodifiers_test.go
+++ b/networkrules/splitmodifiers_test.go
@@ -69,7 +69,7 @@ func TestSplitModifiers(t *testing.T) {
 			want: []string{`a\`},
 		},
 		{
-			// https://github.com/ZenPrivacy/zen-desktop/issues/509
+			// https://github.com/irbis-sh/zen-desktop/issues/509
 			in:   `removeparam=/^WT\..*$/i,thirdparty`,
 			want: []string{`removeparam=/^WT\..*$/i`, "thirdparty"},
 		},

--- a/process/process_test.go
+++ b/process/process_test.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/ZenPrivacy/zen-core/process"
+	"github.com/irbis-sh/zen-core/process"
 )
 
 func TestFindBySourcePort(t *testing.T) {

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -17,8 +17,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/ZenPrivacy/zen-core/internal/redacted"
-	"github.com/ZenPrivacy/zen-core/process"
+	"github.com/irbis-sh/zen-core/internal/redacted"
+	"github.com/irbis-sh/zen-core/process"
 )
 
 // certGenerator is an interface capable of generating certificates for the proxy.

--- a/proxy/websocket.go
+++ b/proxy/websocket.go
@@ -8,7 +8,7 @@ import (
 	"net"
 	"net/http"
 
-	"github.com/ZenPrivacy/zen-core/internal/redacted"
+	"github.com/irbis-sh/zen-core/internal/redacted"
 )
 
 func (p *Proxy) proxyWebsocketTLS(w http.ResponseWriter, req *http.Request) {

--- a/sysproxy/exclusions/common.txt
+++ b/sysproxy/exclusions/common.txt
@@ -116,7 +116,7 @@ ab.chatgpt.com
 oaiusercontent.com
 
 # Issues
-# https://github.com/ZenPrivacy/zen-desktop/pull/223
+# https://github.com/irbis-sh/zen-desktop/pull/223
 account.booking.com
-# https://github.com/ZenPrivacy/zen-desktop/issues/407
+# https://github.com/irbis-sh/zen-desktop/issues/407
 updates.ghub.logitechg.com


### PR DESCRIPTION
### What does this PR do?

- Rename the module to `github.com/irbis-sh/zen-core`, update associated imports
- Update `zenprivacy.net` links to `irbis.sh`
- Update copyright owners to `Irbis & Zen contributors`

### How did you verify your code works?

Linter runs, manual checking.

### What are the relevant issues?

<!--
**Please link any relevant issues**, for example:

Closes #123
-->
